### PR TITLE
ThreadSafeCache performance improvement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,21 +66,21 @@ cache = LruRedux::ThreadSafeCache.new(100)
 see: benchmark directory (a million random lookup / store)
 
 ```
-sam@ubuntu:~/Source/lru_redux/bench$ ruby ./bench.rb
+$ ruby ./bench/bench.rb
 Rehearsal ---------------------------------------------------------
-thread safe lru        27.940000   0.020000  27.960000 ( 28.026869)
-lru gem                 2.250000   0.010000   2.260000 (  2.256652)
-lru_cache gem           1.980000   0.000000   1.980000 (  1.979244)
-lru_redux gem           1.190000   0.000000   1.190000 (  1.187640)
-lru_redux thread safe   2.480000   0.000000   2.480000 (  2.486314)
------------------------------------------------ total: 35.870000sec
+thread safe lru         4.530000   0.020000   4.550000 (  4.540861)
+lru gem                 2.040000   0.000000   2.040000 (  2.046777)
+lru_cache gem           1.660000   0.010000   1.670000 (  1.670404)
+lru_redux gem           1.200000   0.000000   1.200000 (  1.197036)
+lru_redux thread safe   2.520000   0.000000   2.520000 (  2.526945)
+----------------------------------------------- total: 11.980000sec
 
                             user     system      total        real
-thread safe lru        28.010000   0.000000  28.010000 ( 28.023534)
-lru gem                 2.250000   0.000000   2.250000 (  2.256425)
-lru_cache gem           1.920000   0.000000   1.920000 (  1.925362)
-lru_redux gem           1.170000   0.000000   1.170000 (  1.170970)
-lru_redux thread safe   2.480000   0.000000   2.480000 (  2.488169)
+thread safe lru         4.550000   0.030000   4.580000 (  4.581848)
+lru gem                 2.060000   0.000000   2.060000 (  2.056636)
+lru_cache gem           1.660000   0.010000   1.670000 (  1.669312)
+lru_redux gem           1.180000   0.000000   1.180000 (  1.187639)
+lru_redux thread safe   2.530000   0.000000   2.530000 (  2.532061)
 
 ```
 

--- a/bench/bench.rb
+++ b/bench/bench.rb
@@ -1,8 +1,8 @@
-require "rubygems"
-require "lru"
-require "benchmark"
-require "lru_cache"
-require "threadsafe-lru"
+require 'rubygems'
+require 'lru'
+require 'benchmark'
+require 'lru_cache'
+require 'threadsafe-lru'
 $LOAD_PATH.unshift File.expand_path '../lib'
 require File.expand_path('../../lib/lru_redux', __FILE__)
 
@@ -24,12 +24,21 @@ bm = Benchmark.bmbm do |bm|
   [
     [lru, "lru gem"],
     [lru_cache, "lru_cache gem"],
-    [lru_redux, "lru_redux gem"],
-    [lru_redux_thread_safe, "lru_redux thread safe"]
   ].each do |cache, name|
     bm.report name do
       1_000_000.times do
         cache[rand(2_000)] ||= :value
+      end
+    end
+  end
+
+  [
+      [lru_redux, "lru_redux gem"],
+      [lru_redux_thread_safe, "lru_redux thread safe"]
+  ].each do |cache, name|
+    bm.report name do
+      1_000_000.times do
+        cache.getset(rand(2_000)) { :value }
       end
     end
   end

--- a/lib/lru_redux/thread_safe_cache.rb
+++ b/lib/lru_redux/thread_safe_cache.rb
@@ -1,22 +1,75 @@
-require 'thread'
 require 'monitor'
 
 class LruRedux::ThreadSafeCache < LruRedux::Cache
   include MonitorMixin
-  def initialize(size)
-    super(size)
+
+  def initialize(max_size)
+    super(max_size)
   end
 
-  def self.synchronize(*methods)
-    methods.each do |method|
-      define_method method do |*args, &blk|
-        synchronize do
-          super(*args,&blk)
-        end
-      end
+  def max_size=(size)
+    synchronize do
+      super(size)
     end
   end
 
-  synchronize :[], :[]=, :each, :to_a, :delete, :count, :valid?, :max_size, :fetch, :getset
+  def getset(key)
+    synchronize do
+      super(key)
+    end
+  end
 
+  def fetch(key)
+    synchronize do
+      super(key)
+    end
+  end
+
+  def [](key)
+    synchronize do
+      super(key)
+    end
+  end
+
+  def []=(key, value)
+    synchronize do
+      super(key, value)
+    end
+  end
+
+  def each
+    synchronize do
+      super
+    end
+  end
+
+  def to_a
+    synchronize do
+      super
+    end
+  end
+
+  def delete(key)
+    synchronize do
+      super(key)
+    end
+  end
+
+  def clear
+    synchronize do
+      super
+    end
+  end
+
+  def count
+    synchronize do
+      super
+    end
+  end
+
+  def valid?
+    synchronize do
+      super
+    end
+  end
 end


### PR DESCRIPTION
Hello,
I experienced a significant performance drop running the included benchmark test when I switched it to `cache.getset(rand(2_000)) { :value }` from `cache[rand(2_000)] ||= :value` .  I believe the culprit to be the coercion  of yield blocks to Procs that occurs with the ThreadSafeCache synchronize class method.  The new implementation is more verbose, but the performance gain is significant and it can easily be refactored as a mixin if needed (e.g. to support any new caches).

#### Test:
New implementation was in its own class for testing.
```ruby
require "benchmark"

$LOAD_PATH.unshift File.expand_path '../lib'
require File.expand_path('../../lib/lru_redux', __FILE__)

lru_redux_thread_safe = LruRedux::ThreadSafeCache.new(1_000)
lru_redux_new_safe = LruRedux::NewSafeCache.new(1_000)

Benchmark.bmbm do |bm|

  [[lru_redux_thread_safe, "lru_redux thread safe"],
   [lru_redux_new_safe, "lru_redux new safe"]
  ].each do |cache, name|
    bm.report name do
      1_000_000.times do
        cache.getset(rand(2_000)) { :value }
      end
    end
  end
end
```

#### Result:
```
Rehearsal ---------------------------------------------------------
lru_redux thread safe   4.390000   0.020000   4.410000 (  4.411816)
lru_redux new safe      2.670000   0.010000   2.680000 (  2.673842)
------------------------------------------------ total: 7.090000sec

user     system      total        real
lru_redux thread safe   4.310000   0.020000   4.330000 (  4.330839)
lru_redux new safe      2.640000   0.000000   2.640000 (  2.643422)
```

#### The branch was passing all tests.
```
Fabulous run in 0.003373s, 6225.9117 runs/s, 18084.7910 assertions/s.

21 runs, 61 assertions, 0 failures, 0 errors, 0 skips
21 tests
61 assertions, 0 failures, 0 errors
```