### PR TITLE
Fix for bug in ThreadSafeCache (JRuby 1.7) and improvement to Cache#delete (legacy)

### DIFF
--- a/lib/lru_redux.rb
+++ b/lib/lru_redux.rb
@@ -12,3 +12,5 @@ else
   require "lru_redux/cache"
 end
 require "lru_redux/thread_safe_cache"
+require "lru_redux/thread_safe_cache_jruby" if
+    RUBY_PLATFORM == 'java' && JRUBY_VERSION < '9.0'

--- a/lib/lru_redux/cache.rb
+++ b/lib/lru_redux/cache.rb
@@ -89,25 +89,16 @@ class LruRedux::Cache
 
   def delete(key)
     node = @data.delete(key)
+
     return unless node
 
-    if node[3].nil?
-      @head = @head[0]
-      if @head.nil?
-        @tail = nil
-      else
-        @head[3] = nil
-      end
-    elsif node[0].nil?
-      @tail = @tail[3]
-      @tail[0] = nil
-    else
-      prev = node[0]
-      nex = node[3]
+    prev = node[0]
+    nex = node[3]
 
-      prev[3] = nex if prev
-      nex[0] = prev if nex
-    end
+    nex  ? nex[0] = prev : @head = prev
+    prev ? prev[3] = nex : @tail = nex
+
+    node[2]
   end
 
   def clear

--- a/lib/lru_redux/thread_safe_cache.rb
+++ b/lib/lru_redux/thread_safe_cache.rb
@@ -13,15 +13,29 @@ class LruRedux::ThreadSafeCache < LruRedux::Cache
     end
   end
 
-  def getset(key)
-    synchronize do
-      super(key)
+  if RUBY_PLATFORM == 'java' && JRUBY_VERSION < '9.0'
+    def getset(key, &block)
+      synchronize do
+        super(key, &block)
+      end
     end
-  end
 
-  def fetch(key)
-    synchronize do
-      super(key)
+    def fetch(key, &block)
+      synchronize do
+        super(key, &block)
+      end
+    end
+  else
+    def getset(key)
+      synchronize do
+        super(key)
+      end
+    end
+
+    def fetch(key)
+      synchronize do
+        super(key)
+      end
     end
   end
 

--- a/lib/lru_redux/thread_safe_cache.rb
+++ b/lib/lru_redux/thread_safe_cache.rb
@@ -13,29 +13,15 @@ class LruRedux::ThreadSafeCache < LruRedux::Cache
     end
   end
 
-  if RUBY_PLATFORM == 'java' && JRUBY_VERSION < '9.0'
-    def getset(key, &block)
-      synchronize do
-        super(key, &block)
-      end
+  def getset(key)
+    synchronize do
+      super(key)
     end
+  end
 
-    def fetch(key, &block)
-      synchronize do
-        super(key, &block)
-      end
-    end
-  else
-    def getset(key)
-      synchronize do
-        super(key)
-      end
-    end
-
-    def fetch(key)
-      synchronize do
-        super(key)
-      end
+  def fetch(key)
+    synchronize do
+      super(key)
     end
   end
 

--- a/lib/lru_redux/thread_safe_cache_jruby.rb
+++ b/lib/lru_redux/thread_safe_cache_jruby.rb
@@ -1,0 +1,13 @@
+class LruRedux::ThreadSafeCache
+  def getset(key, &block)
+    synchronize do
+      super(key, &block)
+    end
+  end
+
+  def fetch(key, &block)
+    synchronize do
+      super(key, &block)
+    end
+  end
+end


### PR DESCRIPTION
Hello,
While working on another project I ran into a bug that affects the current ThreadSafeCache implementation.

### ThreadSafeCache Bug (JRuby 1.7)
The bug that was introduced with #5 (I am ashamed to say) and affects JRuby 1.7.  It does not affect JRuby 9000.

```ruby
# JRuby 1.7.19
cache = LruRedux::ThreadSafeCache.new(3)

cache.getset(:a) { :value }
# throws LocalJumpError: yield called out of block
```

This error appears to indicate that JRuby 1.7 does not pass the block down to super like the MRI ( http://stackoverflow.com/questions/119207/what-does-yield-called-out-of-block-mean-in-ruby ). This branch changes ThreadSafeCache to explicitly pass `&block` if it is run by a JRuby version lower than 9.0.  This allows us to keep the performance boost of #5 on all but JRuby 1.7.

### Improvement to Cache#delete (legacy)
The code of Cache#delete seemed verbose when I submitted it (it was).  This branch simplifies its code and also modifies its behavior.  It will now act like the 1.9 version and return the deleted value or nil.

### Benchmarks
This branch does not change the runtime performance.

### Tests
This branch is passing all tests, including JRuby 1.7.19 and JRuby 9.0.0.0-pre1
```ruby
Fabulous run in 0.002235s, 9395.9732 runs/s, 27293.0649 assertions/s.

21 runs, 61 assertions, 0 failures, 0 errors, 0 skips
21 tests
61 assertions, 0 failures, 0 errors

8742.71 tests/s, 25395.50 assertions/s
```