### PR TITLE
TTL Cache and New Reader Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # LruRedux [![Gem Version](https://badge.fury.io/rb/lru_redux.svg)](http://badge.fury.io/rb/lru_redux)
 An efficient, thread safe LRU cache.
 
-[Installation](#installation)
-[Usage](#usage)
-[Cache Methods](#cache+methods)
-[Benchmarks](#benchmarks)
-[Other Caches](#other+caches)
-[Contributing](#contributing)
-[Changelog](#changelog)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Cache Methods](#cache-methods)
+- [Benchmarks](#benchmarks)
+- [Other Caches](#other-caches)
+- [Contributing](#contributing)
+- [Changelog](#changelog)
 
 ## Installation
 
@@ -76,7 +76,7 @@ The TTL cache extends the functionality of the LRU cache with a Time To Live evi
 # and is used for demonstration purposes.
 
 # Create a TTL cache with a size of 100 and TTL of 5 minutes.
-cache = LruRedux::Cache.new(100, 5 * 60)
+cache = LruRedux::TTL::Cache.new(100, 5 * 60)
 
 Timecop.freeze(Time.now)
 
@@ -193,20 +193,20 @@ LruRedux::TTL::Cache (TTL disabled)   2.440000   0.000000   2.440000 (  2.446269
 This is a list of the caches that are used in the benchmarks.
 
 #### LRU
-RubyGems: https://rubygems.org/gems/lru
-Homepage: http://lru.rubyforge.org/
+- RubyGems: https://rubygems.org/gems/lru
+- Homepage: http://lru.rubyforge.org/
 
 #### LRUCache
-RubyGems: https://rubygems.org/gems/lru_cache
-Homepage: https://github.com/brendan/lru_cache
+- RubyGems: https://rubygems.org/gems/lru_cache
+- Homepage: https://github.com/brendan/lru_cache
 
 #### ThreadSafeLru
-RubyGems: https://rubygems.org/gems/threadsafe-lru
-Homepage: https://github.com/draganm/threadsafe-lru
+- RubyGems: https://rubygems.org/gems/threadsafe-lru
+- Homepage: https://github.com/draganm/threadsafe-lru
 
 #### FastCache
-RubyGems: https://rubygems.org/gems/fast_cache
-Homepage: https://github.com/swoop-inc/fast_cache
+- RubyGems: https://rubygems.org/gems/fast_cache
+- Homepage: https://github.com/swoop-inc/fast_cache
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ cache = LruRedux::ThreadSafeCache.new(100)
 
 see: benchmark directory (a million random lookup / store)
 
+#### LRU
 ```
 $ ruby ./bench/bench.rb
 Rehearsal ---------------------------------------------------------
@@ -88,6 +89,22 @@ lru_redux thread safe   2.190000   0.010000   2.200000 (  2.185512)
 
 ```
 
+#### TTL
+```
+$ ruby ./bench/bench_ttl.rb
+Rehearsal -----------------------------------------------------------------------
+FastCache                             6.240000   0.070000   6.310000 (  6.302569)
+LruRedux::TTL::Cache                  4.700000   0.010000   4.710000 (  4.712858)
+LruRedux::TTL::ThreadSafeCache        6.300000   0.010000   6.310000 (  6.319032)
+LruRedux::TTL::Cache (TTL disabled)   2.460000   0.010000   2.470000 (  2.470629)
+------------------------------------------------------------- total: 19.800000sec
+
+                                          user     system      total        real
+FastCache                             6.470000   0.070000   6.540000 (  6.536193)
+LruRedux::TTL::Cache                  4.640000   0.010000   4.650000 (  4.661793)
+LruRedux::TTL::ThreadSafeCache        6.310000   0.020000   6.330000 (  6.328840)
+LruRedux::TTL::Cache (TTL disabled)   2.440000   0.000000   2.440000 (  2.446269)
+```
 
 ## Contributing
 
@@ -98,6 +115,10 @@ lru_redux thread safe   2.190000   0.010000   2.200000 (  2.185512)
 5. Create new Pull Request
 
 ## Changlog
+###version NEXT - TBD
+
+- New: TTL cache added.  This cache is LRU like with the addition of time-based eviction.  Check the TTL section in README.md for details.
+
 ###version 1.0.0 - 26-Mar-2015
 
 - Ruby Support: Ruby 1.9+ is now required by LruRedux.  If you need to use LruRedux in Ruby 1.8, please specify gem version 0.8.4 in your Gemfile.  v0.8.4 is the last 1.8 compatible release and included a number of fixes and performance improvements for the Ruby 1.8 implementation. @Seberius

--- a/Rakefile
+++ b/Rakefile
@@ -3,5 +3,5 @@ require "bundler/gem_tasks"
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|
-  t.pattern = "test/*_test.rb"
+  t.pattern = "test/**/*_test.rb"
 end

--- a/bench/bench.rb
+++ b/bench/bench.rb
@@ -1,45 +1,43 @@
 require 'bundler'
-require 'lru'
 require 'benchmark'
+require 'lru'
 require 'lru_cache'
 require 'threadsafe-lru'
 
 Bundler.require
 
-lru = Cache::LRU.new(:max_elements => 1_000)
+# Lru
+lru = Cache::LRU.new(max_elements: 1_000)
+
+# LruCache
 lru_cache = LRUCache.new(1_000)
 
-lru_redux = LruRedux::Cache.new(1_000)
-lru_redux_thread_safe = LruRedux::ThreadSafeCache.new(1_000)
+# ThreadSafeLru
 thread_safe_lru = ThreadSafeLru::LruCache.new(1_000)
 
+# LruRedux
+redux = LruRedux::Cache.new(1_000)
+redux_thread_safe = LruRedux::ThreadSafeCache.new(1_000)
+
+puts "** LRU Benchmarks **"
 Benchmark.bmbm do |bm|
-
-  bm.report "thread safe lru" do
-    1_000_000.times do
-      thread_safe_lru.get(rand(2_000)){ :value }
-    end
+  bm.report 'ThreadSafeLru' do
+    1_000_000.times { thread_safe_lru.get(rand(2_000)) { :value } }
   end
 
-  [
-    [lru, "lru gem"],
-    [lru_cache, "lru_cache gem"],
-  ].each do |cache, name|
-    bm.report name do
-      1_000_000.times do
-        cache[rand(2_000)] ||= :value
-      end
-    end
+  bm.report 'LRU' do
+    1_000_000.times { lru[rand(2_000)] ||= :value }
   end
 
-  [
-      [lru_redux, "lru_redux gem"],
-      [lru_redux_thread_safe, "lru_redux thread safe"]
-  ].each do |cache, name|
-    bm.report name do
-      1_000_000.times do
-        cache.getset(rand(2_000)) { :value }
-      end
-    end
+  bm.report 'LRUCache' do
+    1_000_000.times { lru_cache[rand(2_000)] ||= :value }
+  end
+
+  bm.report 'LruRedux::Cache' do
+    1_000_000.times { redux.getset(rand(2_000)) { :value } }
+  end
+
+  bm.report 'LruRedux::ThreadSafeCache' do
+    1_000_000.times { redux_thread_safe.getset(rand(2_000)) { :value } }
   end
 end

--- a/bench/bench_ttl.rb
+++ b/bench/bench_ttl.rb
@@ -1,0 +1,33 @@
+require 'bundler'
+require 'benchmark'
+require 'fast_cache'
+
+Bundler.require
+
+# FastCache
+fast_cache = FastCache::Cache.new(1_000, 5 * 60)
+
+# LruRedux
+redux_ttl = LruRedux::TTL::Cache.new(1_000, 5 * 60)
+redux_ttl_thread_safe = LruRedux::TTL::ThreadSafeCache.new(1_000, 5 * 60)
+redux_ttl_disabled = LruRedux::TTL::Cache.new(1_000, :none)
+
+puts
+puts "** TTL Benchmarks **"
+Benchmark.bmbm do |bm|
+  bm.report 'FastCache' do
+    1_000_000.times { fast_cache.fetch(rand(2_000)) { :value } }
+  end
+
+  bm.report 'LruRedux::TTL::Cache' do
+    1_000_000.times { redux_ttl.getset(rand(2_000)) { :value } }
+  end
+
+  bm.report 'LruRedux::TTL::ThreadSafeCache' do
+    1_000_000.times { redux_ttl_thread_safe.getset(rand(2_000)) { :value } }
+  end
+
+  bm.report 'LruRedux::TTL::Cache (TTL disabled)' do
+    1_000_000.times { redux_ttl_disabled.getset(rand(2_000)) { :value } }
+  end
+end

--- a/lib/lru_redux.rb
+++ b/lib/lru_redux.rb
@@ -6,4 +6,6 @@ require "lru_redux/cache_legacy" if
 
 require "lru_redux/thread_safe_cache"
 
+require "lru_redux/ttl"
+
 require "lru_redux/version"

--- a/lib/lru_redux/cache.rb
+++ b/lib/lru_redux/cache.rb
@@ -5,7 +5,7 @@ class LruRedux::Cache
   def initialize(*args)
     max_size, _ = args
 
-    raise ArgumentError.new(:max_size) if @max_size < 1
+    raise ArgumentError.new(:max_size) if max_size < 1
 
     @max_size = max_size
     @data = {}
@@ -14,7 +14,7 @@ class LruRedux::Cache
   def max_size=(max_size)
     max_size ||= @max_size
 
-    raise ArgumentError.new(:max_size) if @max_size < 1
+    raise ArgumentError.new(:max_size) if max_size < 1
 
     @max_size = max_size
 

--- a/lib/lru_redux/cache.rb
+++ b/lib/lru_redux/cache.rb
@@ -99,6 +99,8 @@ class LruRedux::Cache
     @data.size
   end
 
+  protected
+
   # for cache validation only, ensures all is sound
   def valid?
     true

--- a/lib/lru_redux/cache.rb
+++ b/lib/lru_redux/cache.rb
@@ -2,16 +2,27 @@
 #
 # This is an ultra efficient 1.9 freindly implementation
 class LruRedux::Cache
-  def initialize(max_size)
+  def initialize(*args)
+    max_size, _ = args
+
+    raise ArgumentError.new(:max_size) if @max_size < 1
+
     @max_size = max_size
     @data = {}
   end
 
-  def max_size=(size)
+  def max_size=(max_size)
+    max_size ||= @max_size
+
     raise ArgumentError.new(:max_size) if @max_size < 1
-    @max_size = size
+
+    @max_size = max_size
 
     @data.shift while @data.size > @max_size
+  end
+
+  def ttl=(_)
+    nil
   end
 
   def getset(key)

--- a/lib/lru_redux/ttl.rb
+++ b/lib/lru_redux/ttl.rb
@@ -1,0 +1,4 @@
+require "lru_redux/util"
+
+require "lru_redux/ttl/cache"
+require "lru_redux/ttl/thread_safe_cache"

--- a/lib/lru_redux/ttl/cache.rb
+++ b/lib/lru_redux/ttl/cache.rb
@@ -1,0 +1,186 @@
+module LruRedux
+  module TTL
+    class Cache
+      def initialize(*args)
+        max_size, ttl = args
+
+        ttl ||= :none
+
+        raise ArgumentError.new(:max_size) if
+            max_size < 1
+        raise ArgumentError.new(:ttl) unless
+            ttl == :none || ((ttl.is_a? Numeric) && ttl >= 0)
+
+        @max_size = max_size
+        @ttl = ttl
+        @data_lru = {}
+        @data_ttl = {}
+      end
+
+      def max_size=(max_size)
+        max_size ||= @max_size
+
+        raise ArgumentError.new(:max_size) if
+            max_size < 1
+
+        @max_size = max_size
+
+        resize
+      end
+
+      def ttl=(ttl)
+        ttl ||= @ttl
+
+        raise ArgumentError.new(:ttl) unless
+            ttl == :none || ((ttl.is_a? Numeric) && ttl >= 0)
+
+        @ttl = ttl
+
+        ttl_evict
+      end
+
+      def getset(key)
+        ttl_evict
+
+        found = true
+        value = @data_lru.delete(key){ found = false }
+        if found
+          @data_lru[key] = value
+        else
+          result = @data_lru[key] = yield
+          @data_ttl = Time.now
+
+          if @data_lru.size > @max_size
+            key, _ = @data_lru.tail
+
+            @data_ttl.delete(key)
+            @data_lru.delete(key)
+          end
+
+          result
+        end
+      end
+
+      def fetch(key)
+        ttl_evict
+
+        found = true
+        value = @data_lru.delete(key){ found = false }
+        if found
+          @data_lru[key] = value
+        else
+          yield if block_given?
+        end
+      end
+
+      def [](key)
+        ttl_evict
+
+        found = true
+        value = @data_lru.delete(key){ found = false }
+        if found
+          @data_lru[key] = value
+        else
+          nil
+        end
+      end
+
+      def []=(key, val)
+        ttl_evict
+
+        @data_lru.delete(key)
+        @data_ttl.delete(key)
+
+        @data_lru[key] = val
+        @data_ttl[key] = Time.now
+
+        if @data_lru.size > @max_size
+          key, _ = @data_lru.tail
+
+          @data_ttl.delete(key)
+          @data_lru.delete(key)
+        end
+
+        val
+      end
+
+      def each
+        ttl_evict
+
+        array = @data_lru.to_a
+        array.reverse!.each do |pair|
+          yield pair
+        end
+      end
+
+      # used further up the chain, non thread safe each
+      alias_method :each_unsafe, :each
+
+      def to_a
+        ttl_evict
+
+        array = @data_lru.to_a
+        array.reverse!
+      end
+
+      def delete(key)
+        ttl_evict
+
+        @data_lru.delete(key)
+        @data_ttl.delete(key)
+      end
+
+      alias_method :evict, :delete
+
+      def key?(key)
+        ttl_evict
+
+        @data_lru.key?(key)
+      end
+
+      alias_method :has_key?, :key?
+
+      def clear
+        @data_lru.clear
+        @data_ttl.clear
+      end
+
+      def count
+        @data_lru.size
+      end
+
+      # for cache validation only, ensures all is sound
+      def valid?
+        @data_lru.size == @data_ttl.size
+      end
+
+      protected
+
+      def ttl_evict
+        return if @ttl == :none
+
+        ttl_horizon = Time.now - @ttl
+        key, time = @data_ttl.tail
+
+        until time.nil? || time > ttl_horizon
+          @data_ttl.delete(key)
+          @data_lru.delete(key)
+
+          key, time = @data_ttl.tail
+        end
+      end
+
+      def resize
+        ttl_evict
+
+        while @data_lru.size > @max_size
+          key, _ = @data_lru.tail
+
+          @data_ttl.delete(key)
+          @data_lru.delete(key)
+        end
+      end
+    end
+  end
+end
+

--- a/lib/lru_redux/ttl/cache.rb
+++ b/lib/lru_redux/ttl/cache.rb
@@ -155,12 +155,12 @@ module LruRedux
         @data_lru.size
       end
 
+      protected
+
       # for cache validation only, ensures all is sound
       def valid?
         @data_lru.size == @data_ttl.size
       end
-
-      protected
 
       def ttl_evict
         return if @ttl == :none

--- a/lib/lru_redux/ttl/thread_safe_cache.rb
+++ b/lib/lru_redux/ttl/thread_safe_cache.rb
@@ -1,0 +1,3 @@
+class LruRedux::TTL::ThreadSafeCache < LruRedux::TTL::Cache
+  include LruRedux::Util::SafeSync
+end

--- a/lib/lru_redux/util/safe_sync.rb
+++ b/lib/lru_redux/util/safe_sync.rb
@@ -5,13 +5,19 @@ module LruRedux
     module SafeSync
       include MonitorMixin
 
-      def initialize(max_size)
-        super(max_size)
+      def initialize(*args)
+        super(*args)
       end
 
-      def max_size=(size)
+      def max_size=(max_size)
         synchronize do
-          super(size)
+          super(max_size)
+        end
+      end
+
+      def ttl=(ttl)
+        synchronize do
+          super(ttl)
         end
       end
 

--- a/lru_redux.gemspec
+++ b/lru_redux.gemspec
@@ -6,8 +6,8 @@ require 'lru_redux/version'
 Gem::Specification.new do |spec|
   spec.name          = "lru_redux"
   spec.version       = LruRedux::VERSION
-  spec.authors       = ["Sam Saffron"]
-  spec.email         = ["sam.saffron@gmail.com"]
+  spec.authors       = ["Sam Saffron", "Kaijah Hougham"]
+  spec.email         = ["sam.saffron@gmail.com", "github@seberius.com"]
   spec.description   = %q{An efficient implementation of an lru cache}
   spec.summary       = %q{An efficient implementation of an lru cache}
   spec.homepage      = "https://github.com/SamSaffron/lru_redux"
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-minitest"
   spec.add_development_dependency "guard"
   spec.add_development_dependency "rb-inotify"
+  spec.add_development_dependency "timecop", "~> 0.7"
 end

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -8,7 +8,7 @@ class CacheTest < MiniTest::Test
   end
 
   def teardown
-    assert_equal true, @c.valid?
+    assert_equal true, @c.send(:valid?)
   end
 
   def test_drops_old

--- a/test/ttl/cache_test.rb
+++ b/test/ttl/cache_test.rb
@@ -1,0 +1,90 @@
+require 'timecop'
+
+class TTLCacheTest < CacheTest
+  def setup
+    Timecop.freeze(Time.now)
+    @c = LruRedux::TTL::Cache.new 3, 5 * 60
+  end
+
+  def teardown
+    Timecop.return
+  end
+
+  def test_ttl
+    assert_equal 300, @c.ttl
+
+    @c.ttl = 10 * 60
+
+    assert_equal 600, @c.ttl
+  end
+
+  # TTL tests using Timecop
+  def test_ttl_eviction_on_access
+    @c[:a] = 1
+    @c[:b] = 2
+
+    Timecop.freeze(Time.now + 330)
+
+    @c[:c] = 3
+
+    assert_equal([[:c, 3]], @c.to_a)
+  end
+
+  def test_ttl_eviction_on_expire
+    @c[:a] = 1
+    @c[:b] = 2
+
+    Timecop.freeze(Time.now + 330)
+
+    @c.expire
+
+    assert_equal([], @c.to_a)
+  end
+
+  def test_ttl_eviction_on_new_max_size
+    @c[:a] = 1
+    @c[:b] = 2
+
+    Timecop.freeze(Time.now + 330)
+
+    @c.max_size = 10
+
+    assert_equal([], @c.to_a)
+  end
+
+  def test_ttl_eviction_on_new_ttl
+    @c[:a] = 1
+    @c[:b] = 2
+
+    Timecop.freeze(Time.now + 330)
+
+    @c.ttl = 10 * 60
+
+    assert_equal([[:b, 2], [:a, 1]], @c.to_a)
+
+    @c.ttl = 2 * 60
+
+    assert_equal([], @c.to_a)
+  end
+
+  def test_ttl_precedence_over_lru
+    @c[:a] = 1
+
+    Timecop.freeze(Time.now + 60)
+
+    @c[:b] = 2
+    @c[:c] = 3
+
+    @c[:a]
+
+    assert_equal [[:a, 1], [:c, 3], [:b, 2]],
+                 @c.to_a
+
+    Timecop.freeze(Time.now + 270)
+
+    @c[:d] = 4
+
+    assert_equal [[:d, 4], [:c, 3], [:b, 2]],
+                 @c.to_a
+  end
+end

--- a/test/ttl/cache_test.rb
+++ b/test/ttl/cache_test.rb
@@ -8,6 +8,7 @@ class TTLCacheTest < CacheTest
 
   def teardown
     Timecop.return
+    assert_equal true, @c.send(:valid?)
   end
 
   def test_ttl

--- a/test/ttl/thread_safe_cache_test.rb
+++ b/test/ttl/thread_safe_cache_test.rb
@@ -4,10 +4,6 @@ class TTLThreadSafeCacheTest < TTLCacheTest
     @c = LruRedux::TTL::ThreadSafeCache.new 3, 5 * 60
   end
 
-  def teardown
-    Timecop.return
-  end
-
   def test_recursion
     @c[:a] = 1
     @c[:b] = 2

--- a/test/ttl/thread_safe_cache_test.rb
+++ b/test/ttl/thread_safe_cache_test.rb
@@ -1,0 +1,20 @@
+class TTLThreadSafeCacheTest < TTLCacheTest
+  def setup
+    Timecop.freeze(Time.now)
+    @c = LruRedux::TTL::ThreadSafeCache.new 3, 5 * 60
+  end
+
+  def teardown
+    Timecop.return
+  end
+
+  def test_recursion
+    @c[:a] = 1
+    @c[:b] = 2
+
+    # should not blow up
+    @c.each do |k, _|
+      @c[k]
+    end
+  end
+end


### PR DESCRIPTION
~~This pull request is NOT complete, as it is missing the updated readme docs for the TTL cache.  This is to give a little extra time for review as it is a large update.~~

#### TTL Cache
This branch introduces a TTL cache to LruRedux.  The TTL cache behaves similarly to the LRU cache, but with time based eviction.

Notes/Features:
- The TTL is based on a cache wide TTL setting.
- TTL eviction takes place at every 'access'.  This guarantees that every time an access operation completes, only live items are stored in the cache.
- TTL eviction takes precedence over LRU eviction.  This guarantees that a 'live' item will never be evicted over a 'dead' one.
- TTL eviction horizon (time to evict) is determined at removal. Specifically, the cache stores entry times, not eviction times.  This means that if the TTL is changed on a live cache, current items will be evicted under the new TTL, not the one they were entered under.
- The TTL can be any positive `Numeric` or `:none`.
- The cache will behave identically to the LRU cache when the TTL is `:none` (and only about twice as slow).
- The TTL value is an optional argument to `#new` ( e.g. `LruRedux::TTL::Cache.new(100)` ) and will default to `:none`.

`test/ttl/cache_test.rb` and the benchmarks in README.md offer some additional behavior and performance information.

Credits: @ssimeonov - [FastCache](https://github.com/swoop-inc/fast_cache), a TTL cache based on LruRedux - (Performance Improvement) Source of the idea to convert Time objects to floats for comparison and storage.

#### New Reader Methods
The reader methods #max_size and #ttl have been added to both caches.  The method #ttl= has also been added to the LRU cache and simply returns nil (not a valid return value for the TTL cache).  This was done to provide a consistent api between the two caches.

#### Gemspec Update
- timecop added as a development dependency.
- Added @Seberius to authors and emails.

#### Tests
This branch is currently passing all tests on 2.2.0 and jruby-1.7.19.
```
Fabulous run in 0.007995s, 7254.5341 runs/s, 16135.0844 assertions/s.

58 runs, 129 assertions, 0 failures, 0 errors, 0 skips
```