### PR TITLE
Replace deprecated MiniTest namespace by Minitest

### DIFF
--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -2,7 +2,7 @@ require 'lru_redux'
 require 'minitest/autorun'
 require 'minitest/pride'
 
-class CacheTest < MiniTest::Test
+class CacheTest < Minitest::Test
   def setup
     @c = LruRedux::Cache.new(3)
   end


### PR DESCRIPTION
The proposed change replaces the deprecated MiniTest namespace by Minitest.
MiniTest is not recognized by newer versions of minitest gem, in particular the one shipped with ruby3.3